### PR TITLE
fix(quickstart): correct CLI commands and card visibility

### DIFF
--- a/src/components/QuickstartSection.tsx
+++ b/src/components/QuickstartSection.tsx
@@ -21,14 +21,14 @@ const STACKS: Record<
     hint: 'Node.js 18+',
     lines: [
       { comment: '# Install', command: 'npm install -g refactron' },
-      { comment: '# Analyze your codebase', command: 'refactron analyze .' },
+      { comment: '# Scan for legacy patterns', command: 'refactron analyze .' },
       {
-        comment: '# Preview refactors',
-        command: 'refactron refactor . --preview',
+        comment: '# Preview the refactor — nothing is written',
+        command: 'refactron run --dry-run .',
       },
       {
-        comment: '# Apply with verification',
-        command: 'refactron refactor . --verify',
+        comment: '# Apply — 3 gates, then atomic write',
+        command: 'refactron run --apply .',
       },
     ],
   },
@@ -37,14 +37,14 @@ const STACKS: Record<
     hint: 'Python 3.8+',
     lines: [
       { comment: '# Install', command: 'pip install refactron' },
-      { comment: '# Analyze your codebase', command: 'refactron analyze .' },
+      { comment: '# Scan for legacy patterns', command: 'refactron analyze .' },
       {
-        comment: '# Preview refactors',
-        command: 'refactron refactor . --preview',
+        comment: '# Preview the refactor — nothing is written',
+        command: 'refactron run --dry-run .',
       },
       {
-        comment: '# Apply with verification',
-        command: 'refactron refactor . --verify',
+        comment: '# Apply — 3 gates, then atomic write',
+        command: 'refactron run --apply .',
       },
     ],
   },
@@ -89,7 +89,7 @@ const QuickstartSection: React.FC = () => {
       <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-b from-black to-transparent z-20 pointer-events-none" />
       <div className="absolute bottom-0 left-0 w-full h-40 bg-gradient-to-t from-black to-transparent z-20 pointer-events-none" />
 
-      <div className="relative z-10 container mx-auto px-4 max-w-7xl">
+      <div className="relative z-30 container mx-auto px-4 max-w-7xl">
         <motion.div
           initial={reduceMotion ? false : { opacity: 0, y: 20 }}
           whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}


### PR DESCRIPTION
Two fixes to the landing page's Quickstart section (`src/components/QuickstartSection.tsx`).

## 1. Stale CLI commands
The snippet used v1-era names that no longer exist in Refactron — anyone copy-pasting would hit "unknown command". Updated both the **npm** and **pip** tabs:

| Before | After |
|---|---|
| `refactron refactor . --preview` | `refactron run --dry-run .` |
| `refactron refactor . --verify` | `refactron run --apply .` |

(`analyze` is unchanged.)

## 2. Card not fully visible
The card content sat at `z-10`, beneath the section's `z-20` top/bottom black-fade gradients — so the card's edges were darkened. Lifted the card to `z-30` so it renders above the gradients. The gradients still fade the ASCII backdrop behind it.

Verified: `eslint` and `prettier --check` both clean.